### PR TITLE
Adding Hello Spark Streaming

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /target/
 /project/target/
 /project/project/
+*.DS_Store*

--- a/README.md
+++ b/README.md
@@ -22,6 +22,10 @@ Run `HelloCassandra`:
 Run `HelloSpark`:
 
     ./sbt "runMain HelloSpark"
+    
+Run `HelloSparkStreaming`:
+
+    ./sbt "runMain HelloSparkStreaming"    
 
 Run `HelloHttp4s`:
 

--- a/build.sbt
+++ b/build.sbt
@@ -2,15 +2,26 @@ name := "kafka-spark-cassandra"
 
 scalaVersion := "2.11.8"
 
+
+val kafkaVersion = "0.10.0.1"
+val akkaStreamKafkaVersion = "0.11-M4"
+val cassandraVersion = "3.7"
+val sparkVersion = "2.0.0"
+val sparkCassandraConnectorVersion = "2.0.0-M1"
+val http4s = "0.14.2a"
+
 libraryDependencies ++= Seq(
-  "org.apache.kafka" %% "kafka" % "0.10.0.1",
-  "com.typesafe.akka" %% "akka-stream-kafka" % "0.11-M4",
-  "org.apache.cassandra" % "cassandra-all" % "3.7",
-  "org.apache.spark" %% "spark-core" % "1.6.2",
-  "org.apache.spark" %% "spark-sql" % "1.6.2",
-  "com.datastax.spark" %% "spark-cassandra-connector" % "1.6.0",
-  "org.http4s"       %% "http4s-dsl"          % "0.14.2a",
-  "org.http4s"       %% "http4s-blaze-server" % "0.14.2a",
+  // kafka is imported as a dependency of spark-streaming-kafka and this version conflicts with that version
+  // "org.apache.kafka" %% "kafka" % kafkaVersion,
+  "com.typesafe.akka" %% "akka-stream-kafka" % akkaStreamKafkaVersion,
+  "org.apache.cassandra" % "cassandra-all" % cassandraVersion,
+  "org.apache.spark" %% "spark-core" % sparkVersion,
+  "org.apache.spark" %% "spark-sql" % sparkVersion,
+  "org.apache.spark" %% "spark-streaming" % sparkVersion,
+  "org.apache.spark" %% "spark-streaming-kafka-0-10" % sparkVersion,
+  "com.datastax.spark" %% "spark-cassandra-connector" % sparkCassandraConnectorVersion,
+  "org.http4s"       %% "http4s-dsl"          % http4s,
+  "org.http4s"       %% "http4s-blaze-server" % http4s,
   "org.scalatest"    %% "scalatest"           % "2.2.6" % "test"
 )
 

--- a/src/main/scala/HelloCassandra.scala
+++ b/src/main/scala/HelloCassandra.scala
@@ -11,6 +11,8 @@ object HelloCassandra extends App {
 
   session.execute("CREATE TABLE IF NOT EXISTS demo.foo (id uuid PRIMARY KEY, name text);")
 
+  session.execute("CREATE TABLE IF NOT EXISTS demo.rand_ints (job_id int, count int, rand_int int, PRIMARY KEY(job_id, count) );")
+
   session.execute(s"INSERT INTO demo.foo (id, name) VALUES (${UUID.randomUUID().toString}, 'bar');")
 
   val results = session.execute("SELECT * FROM demo.foo;")

--- a/src/main/scala/HelloKafka.scala
+++ b/src/main/scala/HelloKafka.scala
@@ -1,4 +1,5 @@
 import java.util.UUID
+import java.util.concurrent.atomic.AtomicInteger
 
 import akka.NotUsed
 import akka.actor.ActorSystem
@@ -8,7 +9,7 @@ import akka.stream.ActorMaterializer
 import akka.stream.scaladsl.{Sink, Source}
 import com.typesafe.config.ConfigFactory
 import org.apache.kafka.clients.producer.ProducerRecord
-import org.apache.kafka.common.serialization.{StringDeserializer, StringSerializer}
+import org.apache.kafka.common.serialization.{IntegerDeserializer, IntegerSerializer, StringDeserializer, StringSerializer}
 
 import scala.concurrent.duration._
 import scala.util.Random
@@ -24,26 +25,29 @@ object HelloKafka extends App {
 
   // Consume Messages
   val consumerConfig = ConfigFactory.defaultReference().getConfig("akka.kafka.consumer")
-  val deserializer = new StringDeserializer()
-  val consumerSettings = ConsumerSettings[String, String](consumerConfig, deserializer, deserializer)
+  val deserializer = new IntegerDeserializer()
+  val consumerSettings = ConsumerSettings[Integer, Integer](consumerConfig, deserializer, deserializer)
     .withBootstrapServers(bootstrapServer)
     .withGroupId(UUID.randomUUID().toString)
 
   val subscription = Subscriptions.topics(topic)
-  Consumer.plainSource(consumerSettings, subscription).runForeach(consumerRecord => println(consumerRecord.value()))
+  Consumer
+    .plainSource(consumerSettings, subscription)
+    .runForeach(consumerRecord => println(s"${consumerRecord.key}:${consumerRecord.value()}"))
 
 
   // Produce Message
+  val count = new AtomicInteger()
   val producerConfig = ConfigFactory.defaultReference().getConfig("akka.kafka.producer")
-  val serializer = new StringSerializer()
-  val producerSettings = ProducerSettings[String, String](producerConfig, serializer, serializer)
+  val serializer = new IntegerSerializer()
+  val producerSettings = ProducerSettings[Integer, Integer](producerConfig, serializer, serializer)
     .withBootstrapServers(bootstrapServer)
 
-  val sink: Sink[ProducerRecord[String, String], NotUsed] = Producer.plainSink(producerSettings)
-  val tickSource = Source.tick(Duration.Zero, 500.milliseconds, Unit).map(_ => Random.nextInt().toString)
+  val sink: Sink[ProducerRecord[Integer, Integer], NotUsed] = Producer.plainSink(producerSettings)
+  val tickSource = Source.tick(Duration.Zero, 500.milliseconds, Unit).map(_ => Random.nextInt())
 
   tickSource
-    .map(new ProducerRecord[String, String](topic, _))
+    .map(new ProducerRecord[Integer, Integer](topic, count.getAndIncrement(), _))
     .to(sink)
     .run()
 

--- a/src/main/scala/HelloSparkStreaming.scala
+++ b/src/main/scala/HelloSparkStreaming.scala
@@ -1,0 +1,69 @@
+
+import com.datastax.driver.core.ConsistencyLevel
+import com.datastax.spark.connector.writer.WriteConf
+import org.apache.kafka.common.serialization.{IntegerDeserializer, StringDeserializer}
+import org.apache.spark.rdd.RDD
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.streaming.kafka010.{ConsumerStrategies, KafkaUtils, LocationStrategies}
+import org.apache.spark.streaming.{Time, Seconds, StreamingContext}
+import org.apache.spark.SparkConf
+import scala.util.Random
+import com.datastax.spark.connector.streaming._
+
+case class RandomJob(job_id: Int, count:Int, rand_int: Int)
+
+object HelloSparkStreaming extends App {
+
+  val rand_job_id = Random.nextInt()
+
+  val conf = new SparkConf(true)
+    .set("spark.cassandra.connection.host", "127.0.0.1")
+    .setMaster("local")
+    .setAppName("RandomJob")
+
+  val sparkStreamingContext = new StreamingContext(conf, Seconds(1))
+
+  val topic = "RandomNumbers"
+  val brokers = "localhost:9092"
+
+  val kafkaParams = Map[String, Object](
+    "bootstrap.servers" -> brokers,
+    "key.deserializer" -> classOf[IntegerDeserializer],
+    "value.deserializer" -> classOf[IntegerDeserializer],
+    "group.id" -> s"consumer-${Random.nextInt}-${System.currentTimeMillis}")
+
+
+  val ls = LocationStrategies.PreferBrokers
+  val cs = ConsumerStrategies.Subscribe[Integer, Integer](List(topic), kafkaParams)
+  val rawKafkaStream = KafkaUtils
+    .createDirectStream[Integer, Integer](sparkStreamingContext, ls, cs)
+
+  private val sparkConf = sparkStreamingContext.sparkContext.getConf
+  private val cassandraWriteConf: WriteConf = WriteConf.fromSparkConf(sparkConf).copy(consistencyLevel = ConsistencyLevel.ONE)
+
+
+  val spark = SparkSession.builder.config(sparkConf).getOrCreate()
+  import spark.implicits._
+
+  val jobStream = rawKafkaStream
+    .map { consumerRecord =>
+      RandomJob(rand_job_id, consumerRecord.key, consumerRecord.value)
+    }
+
+    jobStream
+      .saveToCassandra("demo", "rand_ints", writeConf = cassandraWriteConf)
+
+    jobStream.foreachRDD {
+      (nxtRandomJob: RDD[RandomJob], batchTime: Time) =>
+        val nextJobDF = nxtRandomJob.toDF()
+         nextJobDF.show()
+    }
+
+
+
+  //Kick off
+  sparkStreamingContext.start()
+  sparkStreamingContext.awaitTermination()
+
+
+}

--- a/src/main/scala/KafkaServer.scala
+++ b/src/main/scala/KafkaServer.scala
@@ -31,8 +31,10 @@ object KafkaServer extends App {
 
   val kafkaProperties = new Properties()
   kafkaProperties.put("zookeeper.connect", "localhost:2181")
+  kafkaProperties.put("broker.id", "1")
 
-  val kafkaConfig = KafkaConfig.fromProps(kafkaProperties)
+  // val kafkaConfig = KafkaConfig.fromProps(kafkaProperties)
+  val kafkaConfig =  new KafkaConfig(kafkaProperties)
 
   val kafka = new KafkaServerStartable(kafkaConfig)
 

--- a/src/main/scala/KafkaServer.scala
+++ b/src/main/scala/KafkaServer.scala
@@ -33,8 +33,7 @@ object KafkaServer extends App {
   kafkaProperties.put("zookeeper.connect", "localhost:2181")
   kafkaProperties.put("broker.id", "1")
 
-  // val kafkaConfig = KafkaConfig.fromProps(kafkaProperties)
-  val kafkaConfig =  new KafkaConfig(kafkaProperties)
+  val kafkaConfig = KafkaConfig.fromProps(kafkaProperties)
 
   val kafka = new KafkaServerStartable(kafkaConfig)
 


### PR DESCRIPTION
Adding Hello Spark Streaming required the following changes:
- Updated the Spark and Spark Streaming Versions to 2.0 to support Kafka 0.10.0
- Updated Spark Cassandra Connector to 2.0.0-M1 to support Spark 2.0
- Added a key to the kafka stream
- Changed the type of the kafka stream to Integers to avoid conversions in Spark Streaming
- Added an additional table to HelloCassandra for SparkStreaming to write to Cassandra with
